### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
-    "start:prod": "node dist/main",
+    "start:prod": "node dist/src/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",


### PR DESCRIPTION
fix start:prod script by changing the value from `node dist/main` to `node dist/src/main` according to the issue: https://github.com/nestjs/typescript-starter/issues/293